### PR TITLE
Temporarily drop support for Python 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ workflows:
   on-commit:
     jobs:
       - python2
-      - python3
+      # - python3
 
   daily:
     triggers:
@@ -121,4 +121,4 @@ workflows:
               only: master
     jobs:
       - python2
-      - python3
+      # - python3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
 
   python3:
     docker:
-      - image: circleci/python:2
+      - image: circleci/python:3
 
     working_directory: ~/repo
 

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
+        # Requires baiji, which does not support python 3.
+        # 'Programming Language :: Python :: 3',
     ]
 )


### PR DESCRIPTION
Tests actually were not running in Python 3. Fixing that revealed a dependency on baiji, which does not run in Python 3. This probably is not an easy dependency to remove, so drop Python 3 support for now.